### PR TITLE
Update $routeParams to $route in resolve property

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,15 +169,15 @@ angular
 				templateUrl: 'views/user.html',
 				controller: 'UserController as user',
 				resolve: {
-					user: function ($routeParams, UserService) {
-						return UserService.getUser($routeParams.id);
+					user: function ($route, UserService) {
+						return UserService.getUser($route.current.params.id);
 					}
 				}
 			});
 	});
 ```
 
-Here we're doing very similar things to what we're doing in our controller - injecting `$route` and our `UserService`, but instead we're returning the promise given to us by our `$http.get` call. Once this promise resolves, `ngRoute` will then render our view.
+Here we're doing very similar things to what we're doing in our controller - injecting `$route` and our `UserService`, but instead we're returning the promise given to us by our `$http.get` call. It's important to note that ``$routeParams` does not work in the resolve property, so instead we are using `$route.current.paras` to get the same results. Once this promise resolves, `ngRoute` will then render our view.
 
 That's great, but now how do we get access to that data? Simple - you notice that we're using the key `user` in our resolve object? We can now inject `user` into our controller, accessing all the data that the resolve gives us.
 


### PR DESCRIPTION
$routeParams does not seem to work in the resolve property even
though this lab appears to show that it does. Prior to this pull,
the text was stating to inject `$route` but the code snippet was
showing the `$routeParams`. See following lab for example in
action if needed.

@PeterBell  @ipc103 